### PR TITLE
Fixed GFont Constructor to have the same parameter order as

### DIFF
--- a/source/java/de/exware/gwtswing/PartitionedPanel.java
+++ b/source/java/de/exware/gwtswing/PartitionedPanel.java
@@ -151,7 +151,7 @@ public class PartitionedPanel extends GComponent
             GLabel label = new GLabel(text);
             label.getPeer().addClassName("gwts-PartitionedPanel-Separator-text");
             GFont font = label.getFont();
-            font = new GFont(font.getFamily(), (int)font.getSize2D(), font.BOLD);
+            font = new GFont(font.getFamily(), font.BOLD, (int)font.getSize2D());
             label.setFont(font);
             add(label, gbc);
             linelabel = new GLabel()

--- a/source/java/de/exware/gwtswing/awt/GFont.java
+++ b/source/java/de/exware/gwtswing/awt/GFont.java
@@ -11,7 +11,7 @@ public class GFont
     private int size;
     private int style = PLAIN;
     
-    public GFont(String familyName, int size, int style)
+    public GFont(String familyName, int style, int size)
     {
         this.familyName = familyName;
         this.size = size;
@@ -25,12 +25,12 @@ public class GFont
 
     public GFont deriveFont(float size)
     {
-        return new GFont(familyName, (int) size, style);
+        return new GFont(familyName, style, (int) size);
     }
     
     public GFont deriveFont(int style)
     {
-        return new GFont(familyName, size, style);
+        return new GFont(familyName, style, size);
     }
     
     public String getFamily()

--- a/source/java/de/exware/gwtswing/awt/GWindow.java
+++ b/source/java/de/exware/gwtswing/awt/GWindow.java
@@ -60,7 +60,7 @@ public class GWindow extends GComponent
         return contentpane;
     }
     
-    private void _add(GComponent comp, Object contraints)
+    protected void _add(GComponent comp, Object contraints)
     {
         super.addImpl(comp, contraints, -1);
     }

--- a/source/java/de/exware/gwtswing/swing/GFrame.java
+++ b/source/java/de/exware/gwtswing/swing/GFrame.java
@@ -73,7 +73,7 @@ public class GFrame extends GWindow
             toolbarMenuContainer = new GPanel();
             toolbarMenuContainer.setLayout(new GGridBagLayout());
             GUtilities.insertClassNameBefore(toolbarMenuContainer.getPeer(), "toolbarMenuContainer");
-            add(toolbarMenuContainer, GBorderLayout.CENTER);
+            _add(toolbarMenuContainer, GBorderLayout.CENTER);
             GGridBagConstraints gbc = new GGridBagConstraints();
             gbc.gridx = 0;
             gbc.gridy = 3;

--- a/source/java/de/exware/gwtswing/swing/GTree.java
+++ b/source/java/de/exware/gwtswing/swing/GTree.java
@@ -341,7 +341,7 @@ public class GTree<T> extends GComponent
             putClientProperty("value", value);
             if(font == null)
             {
-                font = new GFont("Courier New", (int) handle.getFont().getSize2D(), GFont.BOLD);
+                font = new GFont("Courier New", GFont.BOLD, (int) handle.getFont().getSize2D());
             }
             handle.setFont(font);
         }

--- a/source/java/de/exware/gwtswing/swing/GUIManager.java
+++ b/source/java/de/exware/gwtswing/swing/GUIManager.java
@@ -102,7 +102,7 @@ public class GUIManager
 //                GwtGPStyleSheet.setPixel(cssrule, "font-size", size);
 //            }
             String family = GPStyleSheet.getProperty(cssrule,"font-family");
-            font = new GFont(family, size, GFont.PLAIN);
+            font = new GFont(family, GFont.PLAIN, size);
             resources.put(key, font);
         }
         return font;


### PR DESCRIPTION
java.awt.Font

- fixed Toolbar in GFrame after changing addImpl() to add to the contentPane instead of the GWindow itself.